### PR TITLE
Fix the train bump animation ending abruptly on mouseout

### DIFF
--- a/things/trains/index.html
+++ b/things/trains/index.html
@@ -35,10 +35,6 @@ subtitle: >-
     }
   }
 
-  .card:hover img {
-    animation: bump 0.5s;
-  }
-
   .card img {
     min-width: 64px;
     display: block;
@@ -166,3 +162,17 @@ subtitle: >-
     <div><p>NS VIRM</p></div>
   </div>
 </div>
+
+<script>
+  document.querySelectorAll(".card img").forEach((img) => {
+    img.addEventListener("mouseover", () => {
+      if (img.style.animation !== "bump 0.5s") {
+        img.style.animation = "bump 0.5s";
+      }
+    });
+
+    img.addEventListener("animationend", () => {
+      img.style.animation = "";
+    });
+  });
+</script>


### PR DESCRIPTION
Previously, the [train animation](https://adryd.com/things/trains/) would end abruptly when the user's cursor left the train area. To resolve this, this PR adds a JavaScript event listener to each image which triggers the animation on mouseover, but does not remove it until it is completed.

As this would be one of the first introductions of JavaScript to the codebase (that I can find), it might be preferable to keep the site HTML/CSS-only and tolerate the current behavior. Unfortunately, with pure CSS, I don't think there's a way for the train icon to "remember" that it needs to be animating after mouseout.